### PR TITLE
Update package-lock.json to address XSS vulnerability in marked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"resolved": "https://registry.npmjs.org/markdown-to-slides/-/markdown-to-slides-1.0.5.tgz",
 			"integrity": "sha1-Zpm9MaHPUYmrjgTC9NzYPB7xhfA=",
 			"requires": {
-				"marked": "0.3.6",
+				"marked": "0.3.9",
 				"marked-to-md": "1.0.1",
 				"mustache": "2.1.3",
 				"optimist": "0.3.7",
@@ -17,9 +17,9 @@
 			}
 		},
 		"marked": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-			"integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+			"integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw=="
 		},
 		"marked-to-md": {
 			"version": "1.0.1",


### PR DESCRIPTION
'marked' has a XSS vulnerability in versions before 0.3.7 - see https://snyk.io/blog/marked-xss-vulnerability/.
This PR updates package-lock.json (note that deleting it before running `npm install` would install the right version).

I find it hard to believe that it would break any of your rendering, but I briefly went through the slides to make sure nothing was obviously broken.